### PR TITLE
Fix interruption when excluded path not exist

### DIFF
--- a/Sources/FengNiaoKit/ExtensionFindProcess.swift
+++ b/Sources/FengNiaoKit/ExtensionFindProcess.swift
@@ -55,18 +55,17 @@ class ExtensionFindProcess: NSObject {
         }
         
         for excludedPath in excluded {
-            args.append("-not")
-            args.append("-path")
-            
             let filePath = path + excludedPath
             guard filePath.exists else { continue }
+            
+            args.append("-not")
+            args.append("-path")
             
             if filePath.isDirectory {
                 args.append("\(filePath.string)/*")
             } else {
                 args.append(filePath.string)
             }
-            
         }
         
         p.arguments = args


### PR DESCRIPTION
When there is a path that does not exist, the 'find' will interrupt for 'find: -path: requires additional arguments'