### PR TITLE
Add .pdf file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ FengNiao supports some arguments. You can find it by:
   -e, --exclude:
       Exclude paths from search.
   -r, --resource-extensions:
-      Resource file extensions need to be searched. Default is 'imageset jpg png gif'
+      Resource file extensions need to be searched. Default is 'imageset jpg png gif pdf'
   -f, --file-extensions:
       In which types of files we should search for resource usage. Default is 'm mm swift xib storyboard'
   --version:
@@ -92,7 +92,7 @@ It is recommended to exclude vendor's folders like Pods or Carthage. Since you d
 
 ## How it works
 
-1. Extract resource file names (default file type: `["imageset", "jpg", "png", "gif"]`) in these folders `["imageset", "launchimage", "appiconset", "bundle”]`. 
+1. Extract resource file names (default file type: `["imageset", "jpg", "png", "gif", "pdf"]`) in these folders `["imageset", "launchimage", "appiconset", "bundle”]`.
 2. Use regular expression to search all string names in files (default files type: `["m", "mm", "swift", "xib", "storyboard", "plist"]`).
 3. Exclude all used string names from resources files, we get all unused resources files.
 

--- a/Sources/FengNiao/main.swift
+++ b/Sources/FengNiao/main.swift
@@ -65,7 +65,7 @@ cli.addOption(excludePathOption)
 
 let resourceExtOption = MultiStringOption(
     shortFlag: "r", longFlag: "resource-extensions",
-    helpMessage: "Resource file extensions need to be searched. Default is 'imageset jpg png gif'")
+    helpMessage: "Resource file extensions need to be searched. Default is 'imageset jpg png gif pdf'")
 cli.addOption(resourceExtOption)
 
 let fileExtOption = MultiStringOption(
@@ -113,7 +113,7 @@ if versionOption.value {
 let projectPath = projectPathOption.value ?? "."
 let isForce = isForceOption.value
 let excludePaths = excludePathOption.value ?? []
-let resourceExtentions = resourceExtOption.value ?? ["imageset", "jpg", "png", "gif"]
+let resourceExtentions = resourceExtOption.value ?? ["imageset", "jpg", "png", "gif", "pdf"]
 let fileExtensions = fileExtOption.value ?? ["h", "m", "mm", "swift", "xib", "storyboard", "plist"]
 
 let fengNiao = FengNiao(projectPath: projectPath,


### PR DESCRIPTION
- Add to PDF file support as default
  - image set support pdf, and PDF file is very useful for using vector image in iOS.
    - https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_ref-Asset_Catalog_Format/ImageSetType.html