### PR TITLE
Add check unuse for Xcode generated asset symbols

### DIFF
--- a/Sources/FengNiaoKit/FengNiao.swift
+++ b/Sources/FengNiaoKit/FengNiao.swift
@@ -311,6 +311,7 @@ extension String {
         }
     }
     
+    /// Example: ic_chat_white -> .icChatWhite
     var generatedAssetSymbolKey: String {
         var ret = "."
         var nextUpper = false

--- a/Sources/FengNiaoKit/FileSearchRule.swift
+++ b/Sources/FengNiaoKit/FileSearchRule.swift
@@ -75,6 +75,24 @@ struct SwiftImageSearchRule: RegPatternSearchRule {
     let patterns = ["\"(.*?)\""]
 }
 
+/*
+Search for potential asset reference to generated asset symbols:
+ - let image = UIImage.icBall
+ - let image: UIImage = .icBall
+ - createThumbnail(image: .icBall)
+ - createThumbnail(
+    image: .icBall
+    )
+ - createThumbnail(
+    image: .icBall,
+    isDark: true
+    )
+ - createThumbnail(
+    image: .icBall.withTintColor(.black),
+    isDark: true
+    )
+ => extract to `.icBall`
+*/
 struct SwiftMemberAccessSearchRule: FileSearchRule {
     func search(in content: String) -> Set<String> {
         let nsstring = NSString(string: content)


### PR DESCRIPTION
### Why?

Currently if image is used only be refer to generated asset symbols from Xcode, FengNiao is identifying as unused although this image is currently used in project like in [this issue](https://github.com/onevcat/FengNiao/issues/79).
<img width="468" height="54" alt="Screenshot 2025-11-22 at 18 07 17" src="https://github.com/user-attachments/assets/58cc460f-72db-4873-a570-caa812ebd542" />


### What changed?
- Add new search rule for Swift file to search for potential generated asset symbols access
- Add addtional code for `filterUnused`, convert resource name to camelCase then check with above potential case

### Testing
I'm testing with my own project
```
let countryViews = [
    CountryView(position: .mid, img: .icNigeria),
    CountryView(position: .right, img: .icJapan),
    CountryView(position: .left, img: .icEngland),
    CountryView(position: .right, img: .icArgentina),
    CountryView(position: .left, img: .icBrazil),
]

final class CountryView: UIView {
    enum Position {
        case left
        case mid
        case right
    }
    
    var position: Position = .left
    var img: UIImage? = nil
    var pinPoint = UIView()
    
    
    init(position: Position, img: UIImage?) {
        self.position = position
        self.img = img
        super.init(frame: .zero)
    }
}
```
Before:
[
<img width="896" height="305" alt="Screenshot 2025-11-22 at 18 18 56" src="https://github.com/user-attachments/assets/73748f81-82fc-4e92-a1a8-ef8083d43e3b" />
](url)
After:
<img width="885" height="296" alt="Screenshot 2025-11-22 at 18 18 17" src="https://github.com/user-attachments/assets/dc3dad18-acd0-4bd2-8601-c50628dd1f6a" />
