### PR TITLE
Fix generate wrong symbol when image name contains number

### DIFF
--- a/Sources/FengNiaoKit/Extensions.swift
+++ b/Sources/FengNiaoKit/Extensions.swift
@@ -66,6 +66,9 @@ extension String {
             switch character {
             case "-", "_", " ":
                 shouldUpperNext = true
+            case let c where c.isNumber:
+                shouldUpperNext = true
+                ret.append(character)
             default:
                 if shouldUpperNext {
                     ret.append(String(character).uppercased())

--- a/Tests/FengNiaoKitTests/FengNiaoKitSpec.swift
+++ b/Tests/FengNiaoKitTests/FengNiaoKitSpec.swift
@@ -51,6 +51,20 @@ public let testFengNiaoKit: ((ContextType) -> Void) = {
             let result = paths.map { $0.plainFileName(extensions: ["png", "jpg"]) }
             try expect(result) == expected
         }
+        
+        $0.it("generatedAssetSymbolKey work properly") {
+            let images = [
+                "ic-chat_white_24 px",
+                "iC-ChAt_whIte_24 pX",
+                "ICCHATWHITE"
+            ]
+            let expected = [
+                ".icChatWhite24Px",
+                ".iCChAtWhIte24PX",
+                ".ICCHATWHITE"
+            ]
+            try expect(images.map { $0.generatedAssetSymbolKey }) == expected
+        }
     }
     
     $0.describe("Int Extesnions") {


### PR DESCRIPTION
### Problem:
Currently for image's name contains digit number following a alphabet character,  the library is generating wrong `generatedAssetSymbolKey` in compare with the Xcode generated one. 

For example, for name `ic_chat_white_24px`:
- FengniaoKit: .icChatWhite24**p**x
- Xcode: .icChatWhite24**P**x

The difference is the letter p after the letter 4.

### Solution:
I have added a fix to uppercase character that following after a digit, also a test case for `generatedAssetSymbolKey` in `String extensions` group .
Alternately, I think we can just compare `generatedAssetSymbolKey` with member access name in lowercase term.