### PR TITLE
Fix asset symbol generation after digits

### DIFF
--- a/Sources/FengNiaoKit/Extensions.swift
+++ b/Sources/FengNiaoKit/Extensions.swift
@@ -68,7 +68,7 @@ extension String {
                 shouldUpperNext = true
             case let c where c.isNumber:
                 shouldUpperNext = true
-                ret.append(character)
+                ret.append(c)
             default:
                 if shouldUpperNext {
                     ret.append(String(character).uppercased())

--- a/Tests/FengNiaoKitTests/FengNiaoKitSpec.swift
+++ b/Tests/FengNiaoKitTests/FengNiaoKitSpec.swift
@@ -52,13 +52,15 @@ public let testFengNiaoKit: ((ContextType) -> Void) = {
             try expect(result) == expected
         }
         
-        $0.it("generatedAssetSymbolKey work properly") {
+        $0.it("generatedAssetSymbolKey works with digits") {
             let images = [
+                "ic_chat_white_24px",
                 "ic-chat_white_24 px",
                 "iC-ChAt_whIte_24 pX",
                 "ICCHATWHITE"
             ]
             let expected = [
+                ".icChatWhite24Px",
                 ".icChatWhite24Px",
                 ".iCChAtWhIte24PX",
                 ".ICCHATWHITE"


### PR DESCRIPTION
This PR is based on #86 and includes the original contributor commit plus follow-up fixes:

- Add a regression test for names like `ic_chat_white_24px` (digit boundary without separators)
- Silence an unused binding warning in `generatedAssetSymbolKey`

Tests:
- `swift test`
