### PR TITLE
Add CI workflow for swift test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Swift Test
+        run: swift test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `swift test` on PRs and master pushes

## Testing
- not run (CI only)
