### PR TITLE
Add support for generated Objective-C asset symbols

### DIFF
--- a/Sources/FengNiaoKit/Extensions.swift
+++ b/Sources/FengNiaoKit/Extensions.swift
@@ -59,9 +59,23 @@ extension String {
     
     /// Convert resource name (snake/kebab case) to generated Swift asset symbol such as `.icChatWhite`.
     var generatedAssetSymbolKey: String {
-        if isEmpty { return "." }
-        var ret = "."
-        var shouldUpperNext = false
+        return convertToCamelCase(prefix: ".", uppercaseFirst: false)
+    }
+    
+    /// Convert resource name (snake/kebab case) to generated Objective-C asset symbol such as `ACImageNameIcFlag`.
+    /// Example: "ic_flag" -> "ACImageNameIcFlag"
+    var objcGeneratedAssetSymbolKey: String {
+        return convertToCamelCase(prefix: "ACImageName", uppercaseFirst: true)
+    }
+    
+    /// Convert resource name (snake/kebab case) to camel case with optional prefix.
+    /// - Parameters:
+    ///   - prefix: The prefix to prepend to the result
+    ///   - uppercaseFirst: Whether the first character after prefix should be uppercase
+    private func convertToCamelCase(prefix: String, uppercaseFirst: Bool) -> String {
+        if isEmpty { return prefix }
+        var ret = prefix
+        var shouldUpperNext = uppercaseFirst
         for character in self {
             switch character {
             case "-", "_", " ":

--- a/Sources/FengNiaoKit/FileSearchRule.swift
+++ b/Sources/FengNiaoKit/FileSearchRule.swift
@@ -80,7 +80,7 @@ struct SwiftMemberAccessSearchRule: FileSearchRule {
     func search(in content: String) -> Set<String> {
         let nsstring = NSString(string: content)
         var result = Set<String>()
-        let pattern = #"(?<![A-Za-z0-9_])(UIImage|UIColor|NSImage|NSColor|Image|Color)?\s*\.\s*([A-Za-z0-9_]+)"#
+        let pattern = #"(?<![A-Za-z0-9_])(ImageResource|UIImage|UIColor|NSImage|NSColor|Image|Color)?\s*\.\s*([A-Za-z0-9_]+)"#
         let reg = try! NSRegularExpression(pattern: pattern, options: [])
         let matches = reg.matches(in: content, options: [], range: content.fullRange)
         for match in matches {

--- a/Tests/FengNiaoKitTests/SearchRuleTests.swift
+++ b/Tests/FengNiaoKitTests/SearchRuleTests.swift
@@ -134,4 +134,33 @@ struct SearchRuleTests {
         let result = searcher.search(in: content)
         #expect(result.isEmpty)
     }
+
+    @Test("Objective-C member access rule applies to generated symbols")
+    func objcMemberAccessRuleAppliesToGeneratedSymbols() {
+        let searcher = ObjCMemberAccessSearchRule()
+        let content = """
+        UIImage *flag = [UIImage imageNamed:ACImageNameIcFlag];
+        UIImage *highlighted = [UIImage imageNamed:ACImageNameIcFlagHighlighted];
+        NSImage *legacy = [NSImage imageNamed:ACImageNameIcFlagSecondary];
+        NSString *name = ACImageNameIcFlag;
+        """
+        let result = searcher.search(in: content)
+        let expected: Set<String> = [
+            "ACImageNameIcFlag",
+            "ACImageNameIcFlagHighlighted",
+            "ACImageNameIcFlagSecondary",
+        ]
+        #expect(result == expected)
+    }
+
+    @Test("Objective-C member access rule ignores regular constants")
+    func objcMemberAccessRuleIgnoresRegularConstants() {
+        let searcher = ObjCMemberAccessSearchRule()
+        let content = """
+        NSString *name = kImageName;
+        NSString *other = SomeOtherConstant;
+        """
+        let result = searcher.search(in: content)
+        #expect(result.isEmpty)
+    }
 }

--- a/Tests/FengNiaoKitTests/SearchRuleTests.swift
+++ b/Tests/FengNiaoKitTests/SearchRuleTests.swift
@@ -85,12 +85,13 @@ struct SearchRuleTests {
         let searcher = SwiftMemberAccessSearchRule()
         let content = """
         let flag = UIImage.icFlag
+        let flag1 = ImageResource.icFlag1
         let highlighted: UIImage = .icFlagHighlighted
         let legacy = NSImage .icFlagSecondary
         let accent = Color .customAccent
         """
         let result = searcher.search(in: content)
-        let expected: Set<String> = [".icFlag", ".icFlagHighlighted", ".icFlagSecondary", ".customAccent"]
+        let expected: Set<String> = [".icFlag", ".icFlag1", ".icFlagHighlighted", ".icFlagSecondary", ".customAccent"]
         #expect(result == expected)
     }
 

--- a/Tests/FengNiaoKitTests/StringExtensionsTests.swift
+++ b/Tests/FengNiaoKitTests/StringExtensionsTests.swift
@@ -41,4 +41,21 @@ struct StringExtensionsTests {
         ]
         #expect(images.map { $0.generatedAssetSymbolKey } == expected)
     }
+    
+    @Test("objcGeneratedAssetSymbolKey converts to Objective-C format")
+    func objcGeneratedAssetSymbolKeyConvertsToObjectiveCFormat() {
+        let images = [
+            "ic_chat_white_24px",
+            "ic-chat_white_24 px",
+            "iC-ChAt_whIte_24 pX",
+            "ICCHATWHITE",
+        ]
+        let expected = [
+            "ACImageNameIcChatWhite24Px",
+            "ACImageNameIcChatWhite24Px",
+            "ACImageNameICChAtWhIte24PX",
+            "ACImageNameICCHATWHITE",
+        ]
+        #expect(images.map { $0.objcGeneratedAssetSymbolKey } == expected)
+    }
 }


### PR DESCRIPTION
 This PR extends FengNiao’s detection of generated asset symbols to Objective‑C and refactors string-to-symbol conversion to a shared helper. It ensures resources referenced via generated symbol constants (both Swift-style .name and Objective‑C-style ACImageNameFoo) are treated as used when scanning a project.

# Why?

Projects that generate Objective‑C constants for assets (or use ObjC code referencing generated symbols) were previously not recognized, which could cause FengNiao to incorrectly mark used resources as unused. This PR closes that gap and consolidates the conversion logic to reduce duplication.

# What changed?

* Sources/FengNiaoKit/Extensions.swift
Introduced convertToCamelCase(prefix:uppercaseFirst:) to centralize camel-case conversions.
Simplified generatedAssetSymbolKey and added objcGeneratedAssetSymbolKey for Objective‑C symbol names (e.g. ACImageNameIcFlag).
* Sources/FengNiaoKit/FengNiao.swift
Detect resources referenced by generated symbols in both Swift (.name) and Objective‑C (ACImageName...).
Broadened member-access search to consider Objective‑C file extensions (.m, .mm, .h) and dispatch per-file to the appropriate search rule.
* Sources/FengNiaoKit/FileSearchRule.swift
Added ObjCMemberAccessSearchRule to find Objective‑C generated symbol constants (e.g. ACImageNameIcFlag).
* Tests/
Added unit tests for ObjCMemberAccessSearchRule and for objcGeneratedAssetSymbolKey in SearchRuleTests.swift and StringExtensionsTests.swift.

# Compatibility & notes?

Backward compatible: existing Swift detection remains unchanged; Objective‑C detection is additive.
A private helper was added; public APIs are unaffected.
Tests added to cover new behavior—please run the test suite and try scanning a sample project that contains Objective‑C references to generated asset symbols.
