### PR TITLE
[codex] Fix generated asset catalog symbol detection

### DIFF
--- a/Sources/FengNiaoKit/Extensions.swift
+++ b/Sources/FengNiaoKit/Extensions.swift
@@ -59,13 +59,18 @@ extension String {
     
     /// Convert resource name (snake/kebab case) to generated Swift asset symbol such as `.icChatWhite`.
     var generatedAssetSymbolKey: String {
-        return convertToCamelCase(prefix: ".", uppercaseFirst: false)
+        return ".\(generatedAssetSymbolPathComponent)"
     }
     
     /// Convert resource name (snake/kebab case) to generated Objective-C asset symbol such as `ACImageNameIcFlag`.
     /// Example: "ic_flag" -> "ACImageNameIcFlag"
     var objcGeneratedAssetSymbolKey: String {
         return convertToCamelCase(prefix: "ACImageName", uppercaseFirst: true)
+    }
+
+    /// Convert a resource name to a single generated Swift member-access component.
+    var generatedAssetSymbolPathComponent: String {
+        return convertToCamelCase(prefix: "", uppercaseFirst: false)
     }
     
     /// Convert resource name (snake/kebab case) to camel case with optional prefix.
@@ -78,7 +83,7 @@ extension String {
         var shouldUpperNext = uppercaseFirst
         for character in self {
             switch character {
-            case "-", "_", " ":
+            case "-", "_", " ", ".":
                 shouldUpperNext = true
             case let c where c.isNumber:
                 shouldUpperNext = true

--- a/Sources/FengNiaoKit/FengNiao.swift
+++ b/Sources/FengNiaoKit/FengNiao.swift
@@ -126,24 +126,16 @@ public struct FengNiao {
         let usedNames = allUsedStringNames()
         let memberAccessUsedNames = allUsedMemberAccessNames()
         
-        // Generated asset symbols are an additional conservative usage signal.
-        // Swift uses `.icFlag`, while Objective-C image symbols use `ACImageNameIcFlag`.
         let resourcesUsedByGeneratedSymbols = Set(
-            allResources.keys.filter { resourceKey in
-                let swiftSymbolKey = resourceKey.generatedAssetSymbolKey
-                if memberAccessUsedNames.contains(swiftSymbolKey) {
-                    return true
-                }
-                let objcImageSymbolKey = resourceKey.objcGeneratedAssetSymbolKey
-                if memberAccessUsedNames.contains(objcImageSymbolKey) {
-                    return true
-                }
-                return false
-            }
+            allResources.values
+                .flatMap { $0 }
+                .filter { isUsedByGeneratedSymbol($0, memberAccessUsedNames: memberAccessUsedNames) }
         )
-        let combinedUsedNames = usedNames.union(resourcesUsedByGeneratedSymbols)
+        let unusedPaths = FengNiao.filterUnused(from: allResources, used: usedNames)
         
-        return FengNiao.filterUnused(from: allResources, used: combinedUsedNames).map( FileInfo.init )
+        return unusedPaths
+            .subtracting(resourcesUsedByGeneratedSymbols)
+            .map(FileInfo.init)
     }
     
     // Return a failed list of deleting
@@ -234,6 +226,51 @@ public struct FengNiao {
             return []
         }
         return usedMemberAccessNames(at: projectPath)
+    }
+
+    func isUsedByGeneratedSymbol(_ resourcePath: String, memberAccessUsedNames: Set<String>) -> Bool {
+        let swiftSymbolKeys = generatedSwiftAssetSymbolKeys(for: resourcePath)
+        if !swiftSymbolKeys.isDisjoint(with: memberAccessUsedNames) {
+            return true
+        }
+
+        let objcSymbolKeys = generatedObjectiveCAssetSymbolKeys(for: resourcePath)
+        if !objcSymbolKeys.isDisjoint(with: memberAccessUsedNames) {
+            return true
+        }
+
+        return false
+    }
+
+    func generatedSwiftAssetSymbolKeys(for resourcePath: String) -> Set<String> {
+        let path = Path(resourcePath)
+        var result: Set<String> = [path.lastComponentWithoutExtension.generatedAssetSymbolKey]
+
+        let components = generatedAssetCatalogSymbolComponents(for: resourcePath)
+        if !components.isEmpty {
+            result.insert(".\(components.joined(separator: "."))")
+        }
+
+        return result
+    }
+
+    func generatedObjectiveCAssetSymbolKeys(for resourcePath: String) -> Set<String> {
+        let path = Path(resourcePath)
+        return [path.lastComponentWithoutExtension.objcGeneratedAssetSymbolKey]
+    }
+
+    func generatedAssetCatalogSymbolComponents(for resourcePath: String) -> [String] {
+        let pathComponents = resourcePath.split(separator: "/").map(String.init)
+        guard let assetCatalogIndex = pathComponents.lastIndex(where: { $0.hasSuffix(".xcassets") }) else {
+            return []
+        }
+        guard assetCatalogIndex < pathComponents.count - 1 else {
+            return []
+        }
+
+        return pathComponents[(assetCatalogIndex + 1)...].map {
+            Path($0).lastComponentWithoutExtension.generatedAssetSymbolPathComponent
+        }
     }
     
     func usedStringNames(at path: Path) -> Set<String> {

--- a/Sources/FengNiaoKit/FileSearchRule.swift
+++ b/Sources/FengNiaoKit/FileSearchRule.swift
@@ -80,10 +80,39 @@ struct SwiftMemberAccessSearchRule: FileSearchRule {
     func search(in content: String) -> Set<String> {
         let nsstring = NSString(string: content)
         var result = Set<String>()
-        let pattern = #"(?<![A-Za-z0-9_])(ImageResource|UIImage|UIColor|NSImage|NSColor|Image|Color)?\s*\.\s*([A-Za-z0-9_]+)"#
+        var excludedRanges: [NSRange] = []
+
+        let nestedPattern = #"(?<![A-Za-z0-9_])(?:UIImage|UIColor|NSImage|NSColor|Image|Color)\s*\(\s*\.([A-Za-z0-9_]+(?:\s*\.\s*[A-Za-z0-9_]+)*)\s*\)"#
+        let nestedReg = try! NSRegularExpression(pattern: nestedPattern, options: [])
+        let nestedMatches = nestedReg.matches(in: content, options: [], range: content.fullRange)
+        for match in nestedMatches {
+            let identifierRange = match.range(at: 1)
+            guard identifierRange.location != NSNotFound else { continue }
+            let identifier = nsstring.substring(with: identifierRange)
+                .replacingOccurrences(of: #"\s*\.\s*"#, with: ".", options: .regularExpression)
+            result.insert(".\(identifier)")
+            excludedRanges.append(match.range)
+        }
+
+        let imageResourcePattern = #"(?<![A-Za-z0-9_])ImageResource\s*\.\s*([A-Za-z0-9_]+(?:\s*\.\s*[A-Za-z0-9_]+)*)"#
+        let imageResourceReg = try! NSRegularExpression(pattern: imageResourcePattern, options: [])
+        let imageResourceMatches = imageResourceReg.matches(in: content, options: [], range: content.fullRange)
+        for match in imageResourceMatches {
+            let identifierRange = match.range(at: 1)
+            guard identifierRange.location != NSNotFound else { continue }
+            let identifier = nsstring.substring(with: identifierRange)
+                .replacingOccurrences(of: #"\s*\.\s*"#, with: ".", options: .regularExpression)
+            result.insert(".\(identifier)")
+            excludedRanges.append(match.range)
+        }
+
+        let pattern = #"(?<![A-Za-z0-9_])(UIImage|UIColor|NSImage|NSColor|Image|Color)?\s*\.\s*([A-Za-z0-9_]+)"#
         let reg = try! NSRegularExpression(pattern: pattern, options: [])
         let matches = reg.matches(in: content, options: [], range: content.fullRange)
         for match in matches {
+            if excludedRanges.contains(where: { NSLocationInRange(match.range.location, $0) }) {
+                continue
+            }
             let identifierRange = match.range(at: 2)
             guard identifierRange.location != NSNotFound else { continue }
             let identifier = nsstring.substring(with: identifierRange)

--- a/Sources/FengNiaoKit/FileSearchRule.swift
+++ b/Sources/FengNiaoKit/FileSearchRule.swift
@@ -106,6 +106,24 @@ struct SwiftMemberAccessSearchRule: FileSearchRule {
             excludedRanges.append(match.range)
         }
 
+        // Catches dot-prefixed nested chains like `.Icons.Settings.logo` regardless of surrounding
+        // call syntax, so type-inference forms (`let r: ImageResource = .A.B.c`,
+        // `UIImage(resource: .A.B.c)`) are not split into single-component leaves by the fallback.
+        let dotPrefixedNestedPattern = #"(?<![A-Za-z0-9_])\.\s*([A-Za-z0-9_]+(?:\s*\.\s*[A-Za-z0-9_]+)+)"#
+        let dotPrefixedNestedReg = try! NSRegularExpression(pattern: dotPrefixedNestedPattern, options: [])
+        let dotPrefixedNestedMatches = dotPrefixedNestedReg.matches(in: content, options: [], range: content.fullRange)
+        for match in dotPrefixedNestedMatches {
+            if excludedRanges.contains(where: { NSLocationInRange(match.range.location, $0) }) {
+                continue
+            }
+            let identifierRange = match.range(at: 1)
+            guard identifierRange.location != NSNotFound else { continue }
+            let identifier = nsstring.substring(with: identifierRange)
+                .replacingOccurrences(of: #"\s*\.\s*"#, with: ".", options: .regularExpression)
+            result.insert(".\(identifier)")
+            excludedRanges.append(match.range)
+        }
+
         let pattern = #"(?<![A-Za-z0-9_])(UIImage|UIColor|NSImage|NSColor|Image|Color)?\s*\.\s*([A-Za-z0-9_]+)"#
         let reg = try! NSRegularExpression(pattern: pattern, options: [])
         let matches = reg.matches(in: content, options: [], range: content.fullRange)

--- a/Tests/FengNiaoKitTests/GeneratedAssetSymbolTests.swift
+++ b/Tests/FengNiaoKitTests/GeneratedAssetSymbolTests.swift
@@ -50,4 +50,19 @@ struct GeneratedAssetSymbolTests {
         let expected: Set<String> = ["ic_unused.png"]
         #expect(fileNames == expected)
     }
+
+    @Test("treats generated asset catalog symbols as usage in nested folders")
+    func treatsGeneratedAssetCatalogSymbolsAsUsageInNestedFolders() throws {
+        let project = fixtures + "GeneratedAssetCatalogSymbol"
+        let fengniao = FengNiao(
+            projectPath: project.string,
+            excludedPaths: [],
+            resourceExtensions: ["imageset"],
+            searchInFileExtensions: ["swift"]
+        )
+        let result = try fengniao.unusedFiles()
+        let fileNames = Set(result.map { $0.fileName })
+        let expected: Set<String> = ["unused.imageset"]
+        #expect(fileNames == expected)
+    }
 }

--- a/Tests/FengNiaoKitTests/SearchRuleTests.swift
+++ b/Tests/FengNiaoKitTests/SearchRuleTests.swift
@@ -136,6 +136,35 @@ struct SearchRuleTests {
         #expect(result.isEmpty)
     }
 
+    @Test("Swift member access rule applies to nested asset catalog symbols")
+    func swiftMemberAccessRuleAppliesToNestedAssetCatalogSymbols() {
+        let searcher = SwiftMemberAccessSearchRule()
+        let content = """
+        let image = Image(.Icons.Settings.logo)
+        let resource = ImageResource.Symbols.plug
+        let direct = Image(ImageResource.emptyIcon)
+        """
+        let result = searcher.search(in: content)
+        let expected: Set<String> = [
+            ".Icons.Settings.logo",
+            ".Symbols.plug",
+            ".emptyIcon",
+        ]
+        #expect(result == expected)
+    }
+
+    @Test("Swift member access rule ignores custom type prefixes that only end with asset type names")
+    func swiftMemberAccessRuleIgnoresCustomTypePrefixesThatOnlyEndWithAssetTypeNames() {
+        let searcher = SwiftMemberAccessSearchRule()
+        let content = """
+        let a = SomeImageResource.icon
+        let b = FooImage.value
+        let c = CustomNSImage.tintColor
+        """
+        let result = searcher.search(in: content)
+        #expect(result.isEmpty)
+    }
+
     @Test("Objective-C member access rule applies to generated symbols")
     func objcMemberAccessRuleAppliesToGeneratedSymbols() {
         let searcher = ObjCMemberAccessSearchRule()

--- a/Tests/FengNiaoKitTests/SearchRuleTests.swift
+++ b/Tests/FengNiaoKitTests/SearchRuleTests.swift
@@ -153,6 +153,20 @@ struct SearchRuleTests {
         #expect(result == expected)
     }
 
+    @Test("Swift member access rule applies to nested symbols via type inference")
+    func swiftMemberAccessRuleAppliesToNestedSymbolsViaTypeInference() {
+        let searcher = SwiftMemberAccessSearchRule()
+        let content = """
+        let r: ImageResource = .Icons.Settings.logo
+        let img = UIImage(resource: .Symbols.plug)
+        let view = ContentView(image: .Icons.Settings.logo, fallback: .emptyIcon)
+        """
+        let result = searcher.search(in: content)
+        #expect(result.contains(".Icons.Settings.logo"))
+        #expect(result.contains(".Symbols.plug"))
+        #expect(result.contains(".emptyIcon"))
+    }
+
     @Test("Swift member access rule ignores custom type prefixes that only end with asset type names")
     func swiftMemberAccessRuleIgnoresCustomTypePrefixesThatOnlyEndWithAssetTypeNames() {
         let searcher = SwiftMemberAccessSearchRule()

--- a/Tests/FengNiaoKitTests/StringExtensionsTests.swift
+++ b/Tests/FengNiaoKitTests/StringExtensionsTests.swift
@@ -58,4 +58,22 @@ struct StringExtensionsTests {
         ]
         #expect(images.map { $0.objcGeneratedAssetSymbolKey } == expected)
     }
+
+    @Test("generated asset symbol keys treat dots as word boundaries")
+    func generatedAssetSymbolKeysTreatDotsAsWordBoundaries() {
+        let images = [
+            "empty.icon",
+            "navigation-menu.row.icon",
+        ]
+        let swiftExpected = [
+            ".emptyIcon",
+            ".navigationMenuRowIcon",
+        ]
+        let objcExpected = [
+            "ACImageNameEmptyIcon",
+            "ACImageNameNavigationMenuRowIcon",
+        ]
+        #expect(images.map { $0.generatedAssetSymbolKey } == swiftExpected)
+        #expect(images.map { $0.objcGeneratedAssetSymbolKey } == objcExpected)
+    }
 }

--- a/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/Contents.json
+++ b/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/Icons/Settings/logo.imageset/Contents.json
+++ b/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/Icons/Settings/logo.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "logo.png",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/Symbols/plug.imageset/Contents.json
+++ b/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/Symbols/plug.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "plug.png",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/empty.icon.imageset/Contents.json
+++ b/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/empty.icon.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "empty.icon.png",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/unused.imageset/Contents.json
+++ b/Tests/Fixtures/GeneratedAssetCatalogSymbol/Assets.xcassets/unused.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "unused.png",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/Fixtures/GeneratedAssetCatalogSymbol/ViewController.swift
+++ b/Tests/Fixtures/GeneratedAssetCatalogSymbol/ViewController.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct SampleView: View {
+    var body: some View {
+        VStack {
+            Image(.Icons.Settings.logo)
+            Image(ImageResource.emptyIcon)
+            Image(ImageResource.Symbols.plug)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a fixture-backed regression test for nested asset catalog symbols, `ImageResource` access, and asset names containing dots
- parse nested Swift member-access symbols without matching unrelated custom type prefixes
- map generated asset symbols from real asset catalog paths so folder-organized assets are preserved without regressing existing Objective-C symbol support

## Root Cause
FengNiao only matched generated Swift asset symbols against the leaf resource key. That worked for simple symbols like `.icFlag`, but not for asset catalogs organized in folders where Xcode generates chained symbols such as `.Icons.Settings.logo`. It also treated dotted asset names like `empty.icon` as literal dots instead of Xcode-style camelCase boundaries.

## Validation
- `swift test --filter FengNiaoKitTests`
